### PR TITLE
fix: handle backward compatibility for listBySession response format

### DIFF
--- a/src/routes/session/[id]/+page.svelte
+++ b/src/routes/session/[id]/+page.svelte
@@ -15,8 +15,17 @@
 	const sessionData = useQuery(api.phrases.listBySession, () => ({ sessionId }));
 
 	// Derived values from the combined query
-	const session = $derived(sessionData.data?.session);
-	const phrases = $derived(sessionData.data?.phrases);
+	// Handle both old format (array) and new format ({ phrases, session })
+	const session = $derived(
+		sessionData.data && 'session' in sessionData.data ? sessionData.data.session : null
+	);
+	const phrases = $derived(
+		sessionData.data
+			? Array.isArray(sessionData.data)
+				? sessionData.data
+				: sessionData.data.phrases
+			: undefined
+	);
 
 	let dialogOpen = $state(false);
 	let english = $state('');


### PR DESCRIPTION
Make the session page handle both the old format (array of phrases) and the new format ({ phrases, session }) to ensure phrases display correctly regardless of which version of the backend is deployed.

https://claude.ai/code/session_01TtBsSivcdSjcgbefJFdL2A