### PR TITLE
fix: pass Uint8Array directly to PushManager.subscribe

### DIFF
--- a/packages/shared/src/notifications.ts
+++ b/packages/shared/src/notifications.ts
@@ -43,7 +43,7 @@ export async function requestNotificationPermission(): Promise<PushSubscription 
 	const applicationServerKey = urlBase64ToUint8Array(VAPID_PUBLIC_KEY);
 	const subscription = await registration.pushManager.subscribe({
 		userVisibleOnly: true,
-		applicationServerKey: applicationServerKey.buffer as ArrayBuffer
+		applicationServerKey
 	});
 
 	return subscription;


### PR DESCRIPTION
.buffer as ArrayBuffer breaks iOS push subscription creation